### PR TITLE
Fixed variable name typo in code examples

### DIFF
--- a/t/01-errors.t
+++ b/t/01-errors.t
@@ -11,7 +11,7 @@ my $parser = Parse::ErrorString::Perl->new;
 # use strict;
 # use warnings;
 #
-# $hell;
+# $kaboom;
 
 my $msg_compile = <<'ENDofMSG';
 Global symbol "$kaboom" requires explicit package name at error.pl line 8.

--- a/t/04-perldiag.t
+++ b/t/04-perldiag.t
@@ -11,7 +11,7 @@ use Test::Differences;
 # use strict;
 # use warnings;
 #
-# $hell;
+# $kaboom;
 
 my $msg_compile;
 


### PR DESCRIPTION
Done as a part of CPAN pull request challenge.